### PR TITLE
Fixed naming bug (clientcpp to cppclient) in nano-client-cpp-config.c…

### DIFF
--- a/extras/nano-client-cpp/nano-client-cpp-config.cmake.in
+++ b/extras/nano-client-cpp/nano-client-cpp-config.cmake.in
@@ -23,7 +23,7 @@ if(NOT "${nano-client_FIND_COMPONENTS}" STREQUAL "")
 endif()
 
 if (NOT TARGET nano::nanoclientcpp)
-    include(${nano-client-cpp_DIR}/nano-client-cpp-clientcpp-targets.cmake)
+    include(${nano-client-cpp_DIR}/nano-client-cpp-cppclient-targets.cmake)
 endif()
 
 foreach(_req_component IN LISTS nano-client-cpp_FIND_COMPONENTS)


### PR DESCRIPTION
Changed nano-client-cpp-clientcpp-targets.cmake to nano-client-cpp-cppclient-targets.cmake to match the relevant file name

File: nano-client-cpp-config.cmake.in
Line: 26