### PR TITLE
Changed parameter names to avoid variable shadowing in NANO_TimeI constructor

### DIFF
--- a/core/include/nano/nano_core_osapi.h
+++ b/core/include/nano/nano_core_osapi.h
@@ -1162,8 +1162,8 @@ typedef struct NANODllExport NANO_TimeI {
     {}
 
     NANO_TimeI(const NANO_i32 s, const NANO_u32 ns)
-    : sec(sec),
-      nanosec(nanosec)
+    : sec(s),
+      nanosec(ns)
     {}
 
 #endif /* NANO_CPP */

--- a/core/include/nano/nano_core_osapi.h
+++ b/core/include/nano/nano_core_osapi.h
@@ -1161,7 +1161,7 @@ typedef struct NANODllExport NANO_TimeI {
       nanosec(0)
     {}
 
-    NANO_TimeI(const NANO_i32 sec, const NANO_u32 nanosec)
+    NANO_TimeI(const NANO_i32 s, const NANO_u32 ns)
     : sec(sec),
       nanosec(nanosec)
     {}


### PR DESCRIPTION
Changed parameter names to avoid variable shadowing in NANO_TimeI constructor

File: core/include/nano/nano_core_osapi.h
Line: 1164-1166